### PR TITLE
add save_text option to save word vectors in a glove format.

### DIFF
--- a/wikipedia2vec/cli.py
+++ b/wikipedia2vec/cli.py
@@ -190,6 +190,7 @@ def train_embedding(dump_file, dictionary_file, link_graph, out_file, **kwargs):
 @cli.command()
 @click.argument('model_file', type=click.Path(exists=True))
 @click.argument('out_file', type=click.Path())
-def save_text(model_file, out_file):
+@click.option('--out_format', default='default')
+def save_text(model_file, out_file, out_format='default'):
     wiki2vec = Wikipedia2Vec.load(model_file)
-    wiki2vec.save_text(out_file)
+    wiki2vec.save_text(out_file, out_format)

--- a/wikipedia2vec/wikipedia2vec.pyx
+++ b/wikipedia2vec/wikipedia2vec.pyx
@@ -149,7 +149,7 @@ cdef class Wikipedia2Vec:
             train_history=self._train_history
         ), out_file)
 
-    def save_text(self, out_file):
+    def save_text(self, out_file, out_format='default'):
         with open(out_file, 'wb') as f:
             for item in sorted(self.dictionary, key=lambda o: o.doc_count, reverse=True):
                 vec_str = ' '.join('%.4f' % v for v in self.get_vector(item))
@@ -158,7 +158,11 @@ cdef class Wikipedia2Vec:
                 else:
                     text = 'ENTITY/' + item.title.replace('\t', ' ')
 
-                f.write(('%s\t%s\n' % (text, vec_str)).encode('utf-8'))
+                if out_format=='glove':
+                    text = text.replace(' ', '_')
+                    f.write(('%s %s\n' % (text, vec_str)).encode('utf-8'))
+                else:
+                    f.write(('%s\t%s\n' % (text, vec_str)).encode('utf-8'))
 
     @staticmethod
     def load(in_file, numpy_mmap_mode='c'):


### PR DESCRIPTION
This change is to add `save_text()` output format option for word vector evaluation. 
By passing `--out_format glove` option , the model will be save as [glove](https://nlp.stanford.edu/projects/glove/) format, where the words are separated by a single space, and for phrases, the spaces between words are replaced by `_`.
Entities are prefixed by "ENTITY/" tag.

```
cuisine 0.2111 -0.0954 0.9485 -0.4581 ...
ENTITY/United_States -0.2026 0.3218 0.1129 0.5457 -0.1619
ENTITY/'Asr_Salaah -0.1846 -0.3632 0.2428 0.1366 ...
```